### PR TITLE
https://huntr.dev/bounties/1-other-mucommander

### DIFF
--- a/mucommander-core/src/main/java/com/mucommander/job/impl/UnpackJob.java
+++ b/mucommander-core/src/main/java/com/mucommander/job/impl/UnpackJob.java
@@ -18,8 +18,7 @@
 
 package com.mucommander.job.impl;
 
-import com.mucommander.commons.file.AbstractFile;
-import com.mucommander.commons.file.ProxyFile;
+import com.mucommander.commons.file.*;
 import com.mucommander.commons.file.archive.AbstractArchiveFile;
 import com.mucommander.commons.file.archive.AbstractRWArchiveFile;
 import com.mucommander.commons.file.archive.ArchiveEntry;
@@ -49,14 +48,10 @@ import java.util.List;
  */
 public class UnpackJob extends AbstractCopyJob {
 
-    /**
-     * Archive entries to be unpacked
-     */
+    /** Archive entries to be unpacked */
     protected List<ArchiveEntry> selectedEntries;
 
-    /**
-     * Depth of the folder in which the top entries are located. 0 is the highest depth (archive's root folder)
-     */
+    /** Depth of the folder in which the top entries are located. 0 is the highest depth (archive's root folder) */
     protected int baseArchiveDepth;
 
 
@@ -66,10 +61,10 @@ public class UnpackJob extends AbstractCopyJob {
      * The base destination folder will be created if it doesn't exist.
      * </p>
      *
-     * @param progressDialog   dialog which shows this job's progress
-     * @param mainFrame        mainFrame this job has been triggered by
-     * @param files            files which are going to be unpacked
-     * @param destFolder       destination folder where the files will be copied
+     * @param progressDialog dialog which shows this job's progress
+     * @param mainFrame mainFrame this job has been triggered by
+     * @param files files which are going to be unpacked
+     * @param destFolder destination folder where the files will be copied
      * @param fileExistsAction default action to be performed when a file already exists in the destination, see {@link com.mucommander.ui.dialog.file.FileCollisionDialog} for allowed values
      */
     public UnpackJob(ProgressDialog progressDialog, MainFrame mainFrame, FileSet files, AbstractFile destFolder, int fileExistsAction) {
@@ -82,11 +77,11 @@ public class UnpackJob extends AbstractCopyJob {
     /**
      * Creates a new UnpackJob without starting it.
      *
-     * @param progressDialog   dialog which shows this job's progress
-     * @param mainFrame        mainFrame this job has been triggered by
-     * @param archiveFile      the archive file which is going to be unpacked
-     * @param destFolder       destination folder where the files will be copied
-     * @param newName          the new filename in the destination folder, if <code>null</code> the original filename will be used
+     * @param progressDialog dialog which shows this job's progress
+     * @param mainFrame mainFrame this job has been triggered by
+     * @param archiveFile the archive file which is going to be unpacked
+     * @param destFolder destination folder where the files will be copied
+     * @param newName the new filename in the destination folder, if <code>null</code> the original filename will be used
      * @param fileExistsAction default action to be performed when a file already exists in the destination, see {@link com.mucommander.ui.dialog.file.FileCollisionDialog} for allowed values
      * @param selectedEntries  entries to be unpacked
      * @param baseArchiveDepth depth of the folder in which the top entries are located. 0 is the highest depth (archive's root folder)
@@ -133,7 +128,7 @@ public class UnpackJob extends AbstractCopyJob {
      * Unpacks the given archive file. If the file is a directory, its children will be processed recursively.
      * If the file is not an archive file nor a directory, it is not processed and <code>false</code> is returned.
      *
-     * @param file          the file to unpack
+     * @param file the file to unpack
      * @param recurseParams unused
      * @return <code>true</code> if the file has been processed successfully
      */

--- a/mucommander-core/src/main/java/com/mucommander/job/impl/UnpackJob.java
+++ b/mucommander-core/src/main/java/com/mucommander/job/impl/UnpackJob.java
@@ -18,7 +18,8 @@
 
 package com.mucommander.job.impl;
 
-import com.mucommander.commons.file.*;
+import com.mucommander.commons.file.AbstractFile;
+import com.mucommander.commons.file.ProxyFile;
 import com.mucommander.commons.file.archive.AbstractArchiveFile;
 import com.mucommander.commons.file.archive.AbstractRWArchiveFile;
 import com.mucommander.commons.file.archive.ArchiveEntry;
@@ -33,6 +34,7 @@ import com.mucommander.ui.action.impl.UnmarkAllAction;
 import com.mucommander.ui.dialog.file.ProgressDialog;
 import com.mucommander.ui.main.MainFrame;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -47,10 +49,14 @@ import java.util.List;
  */
 public class UnpackJob extends AbstractCopyJob {
 
-    /** Archive entries to be unpacked */
+    /**
+     * Archive entries to be unpacked
+     */
     protected List<ArchiveEntry> selectedEntries;
 
-    /** Depth of the folder in which the top entries are located. 0 is the highest depth (archive's root folder) */
+    /**
+     * Depth of the folder in which the top entries are located. 0 is the highest depth (archive's root folder)
+     */
     protected int baseArchiveDepth;
 
 
@@ -60,10 +66,10 @@ public class UnpackJob extends AbstractCopyJob {
      * The base destination folder will be created if it doesn't exist.
      * </p>
      *
-     * @param progressDialog dialog which shows this job's progress
-     * @param mainFrame mainFrame this job has been triggered by
-     * @param files files which are going to be unpacked
-     * @param destFolder destination folder where the files will be copied
+     * @param progressDialog   dialog which shows this job's progress
+     * @param mainFrame        mainFrame this job has been triggered by
+     * @param files            files which are going to be unpacked
+     * @param destFolder       destination folder where the files will be copied
      * @param fileExistsAction default action to be performed when a file already exists in the destination, see {@link com.mucommander.ui.dialog.file.FileCollisionDialog} for allowed values
      */
     public UnpackJob(ProgressDialog progressDialog, MainFrame mainFrame, FileSet files, AbstractFile destFolder, int fileExistsAction) {
@@ -76,13 +82,13 @@ public class UnpackJob extends AbstractCopyJob {
     /**
      * Creates a new UnpackJob without starting it.
      *
-     * @param progressDialog dialog which shows this job's progress
-     * @param mainFrame mainFrame this job has been triggered by
-     * @param archiveFile the archive file which is going to be unpacked
-     * @param destFolder destination folder where the files will be copied
-     * @param newName the new filename in the destination folder, if <code>null</code> the original filename will be used
+     * @param progressDialog   dialog which shows this job's progress
+     * @param mainFrame        mainFrame this job has been triggered by
+     * @param archiveFile      the archive file which is going to be unpacked
+     * @param destFolder       destination folder where the files will be copied
+     * @param newName          the new filename in the destination folder, if <code>null</code> the original filename will be used
      * @param fileExistsAction default action to be performed when a file already exists in the destination, see {@link com.mucommander.ui.dialog.file.FileCollisionDialog} for allowed values
-     * @param selectedEntries entries to be unpacked
+     * @param selectedEntries  entries to be unpacked
      * @param baseArchiveDepth depth of the folder in which the top entries are located. 0 is the highest depth (archive's root folder)
      */
     public UnpackJob(ProgressDialog progressDialog, MainFrame mainFrame, AbstractArchiveFile archiveFile, int baseArchiveDepth, AbstractFile destFolder, String newName, int fileExistsAction, List<ArchiveEntry> selectedEntries) {
@@ -103,24 +109,23 @@ public class UnpackJob extends AbstractCopyJob {
         super.jobStarted();
 
         // Create the base destination folder if it doesn't exist yet
-        if(!baseDestFolder.exists()) {
+        if (!baseDestFolder.exists()) {
             // Loop for retry
             do {
                 try {
                     baseDestFolder.mkdir();
-                }
-                catch(IOException e) {
+                } catch (IOException e) {
                     // Unable to create folder
                     int ret = showErrorDialog(errorDialogTitle, Translator.get("cannot_create_folder", baseDestFolder.getName()));
                     // Retry loops
-                    if(ret==FileJobAction.RETRY)
+                    if (ret == FileJobAction.RETRY)
                         continue;
                     // Cancel or close dialog interrupts the job
                     interrupt();
                     // Skip continues
                 }
                 break;
-            } while(true);
+            } while (true);
         }
     }
 
@@ -128,7 +133,7 @@ public class UnpackJob extends AbstractCopyJob {
      * Unpacks the given archive file. If the file is a directory, its children will be processed recursively.
      * If the file is not an archive file nor a directory, it is not processed and <code>false</code> is returned.
      *
-     * @param file the file to unpack
+     * @param file          the file to unpack
      * @param recurseParams unused
      * @return <code>true</code> if the file has been processed successfully
      */
@@ -142,14 +147,14 @@ public class UnpackJob extends AbstractCopyJob {
         AbstractFile destFolder = baseDestFolder;
 
         // If the file is a directory, process its children recursively
-        if(file.isDirectory()) {
+        if (file.isDirectory()) {
             do {    // Loop for retries
                 try {
                     // List files inside archive file (can throw an IOException)
                     AbstractFile[] archiveFiles = getCurrentFile().ls();
 
                     // Recurse on zip's contents
-                    for(int j=0; j<archiveFiles.length && getState() != FileJobState.INTERRUPTED; j++) {
+                    for (int j = 0; j < archiveFiles.length && getState() != FileJobState.INTERRUPTED; j++) {
                         // Notify job that we're starting to process this file (needed for recursive calls to processFile)
                         nextFile(archiveFiles[j]);
                         // Recurse
@@ -157,21 +162,20 @@ public class UnpackJob extends AbstractCopyJob {
                     }
                     // Return true when complete
                     return true;
-                }
-                catch(IOException e) {
+                } catch (IOException e) {
                     // File could not be uncompressed properly
                     int ret = showErrorDialog(errorDialogTitle, Translator.get("cannot_read_file", getCurrentFilename()));
                     // Retry loops
-                    if(ret==FileJobAction.RETRY)
+                    if (ret == FileJobAction.RETRY)
                         continue;
                     // cancel, skip or close dialog will simply return false
                     return false;
                 }
-            } while(true);
+            } while (true);
         }
 
         // Abort if the file is neither an archive file nor a directory
-        if(!file.isArchive())
+        if (!file.isArchive())
             return false;
 
         // 'Cast' the file as an archive file
@@ -188,28 +192,26 @@ public class UnpackJob extends AbstractCopyJob {
         // Unpack the archive, copying entries one by one, in the iterator's order
         try {
             iterator = archiveFile.getEntryIterator();
-            while((entry = iterator.nextEntry())!=null && getState() != FileJobState.INTERRUPTED) {
+            while ((entry = iterator.nextEntry()) != null && getState() != FileJobState.INTERRUPTED) {
                 entryPath = entry.getPath();
 
                 boolean processEntry = false;
-                if(selectedEntries ==null) {    // Entries are processed
+                if (selectedEntries == null) {    // Entries are processed
                     processEntry = true;
-                }
-                else {                          // We need to determine if the entry should be processed or not
+                } else {                          // We need to determine if the entry should be processed or not
                     // Process this entry if the selectedEntries set contains this entry, or a parent of this entry
                     int nbSelectedEntries = selectedEntries.size();
-                    for(int i=0; i<nbSelectedEntries; i++) {
+                    for (int i = 0; i < nbSelectedEntries; i++) {
                         ArchiveEntry selectedEntry = selectedEntries.get(i);
                         // Note: paths of directory entries must end with '/', so this compares whether
                         // selectedEntry is a parent of the current entry.
-                        if(selectedEntry.isDirectory()) {
-                            if(entryPath.startsWith(selectedEntry.getPath())) {
+                        if (selectedEntry.isDirectory()) {
+                            if (entryPath.startsWith(selectedEntry.getPath())) {
                                 processEntry = true;
                                 break;
                                 // Note: we can't remove selectedEntryPath from the set, we still need it
                             }
-                        }
-                        else if(entryPath.equals(selectedEntry.getPath())) {
+                        } else if (entryPath.equals(selectedEntry.getPath())) {
                             // If the (regular file) entry is in the set, remove it as we no longer need it (will speed up
                             // subsequent searches)
                             processEntry = true;
@@ -219,7 +221,7 @@ public class UnpackJob extends AbstractCopyJob {
                     }
                 }
 
-                if(!processEntry)
+                if (!processEntry)
                     continue;
 
                 // Resolve the entry file
@@ -229,21 +231,25 @@ public class UnpackJob extends AbstractCopyJob {
                 nextFile(entryFile);
 
                 // Figure out the destination file's path, relatively to the base destination folder
-                relDestPath = baseArchiveDepth==0
-                        ?entry.getPath()
-                        :PathUtils.removeLeadingFragments(entry.getPath(), "/", baseArchiveDepth);
+                relDestPath = baseArchiveDepth == 0
+                        ? entry.getPath()
+                        : PathUtils.removeLeadingFragments(entry.getPath(), "/", baseArchiveDepth);
 
-                if(newName!=null)
-                    relDestPath = newName+(PathUtils.getDepth(relDestPath, "/")<=1?"":"/"+PathUtils.removeLeadingFragments(relDestPath, "/", 1));
+                if (newName != null)
+                    relDestPath = newName + (PathUtils.getDepth(relDestPath, "/") <= 1 ? "" : "/" + PathUtils.removeLeadingFragments(relDestPath, "/", 1));
 
-                if(!"/".equals(destSeparator))
+                if (!"/".equals(destSeparator))
                     relDestPath = relDestPath.replace("/", destSeparator);
-
                 // Create destination AbstractFile instance
                 destFile = destFolder.getChild(relDestPath);
 
+
+                //Check for ZipSlip
+                if(!checkForZipSlip(destFile, destFolder))
+                    return false;
+
                 // Do nothing if the file is a symlink (skip file and return)
-                if(entryFile.isSymlink())
+                if (entryFile.isSymlink())
                     return true;
 
                 // Check if the file does not already exist in the destination
@@ -256,36 +262,34 @@ public class UnpackJob extends AbstractCopyJob {
                 // It is noteworthy that the iterator returns entries in no particular order (consider it random).
                 // For that reason, we cannot assume that the parent directory of an entry will be processed
                 // before the entry itself.
-
                 // If the entry is a directory ...
-                if(entryFile.isDirectory()) {
+                if (entryFile.isDirectory()) {
                     // Create the directory in the destination, if it doesn't already exist
-                    if(!(destFile.exists() && destFile.isDirectory())) {
+                    if (!(destFile.exists() && destFile.isDirectory())) {
                         // Loop for retry
                         do {
                             try {
                                 // Use mkdirs() instead of mkdir() to create any parent folder that doesn't exist yet
                                 destFile.mkdirs();
-                            }
-                            catch(IOException e) {
+                            } catch (IOException e) {
                                 // Unable to create folder
                                 int ret = showErrorDialog(errorDialogTitle, Translator.get("cannot_create_folder", entryFile.getName()));
                                 // Retry loops
-                                if(ret==FileJobAction.RETRY)
+                                if (ret == FileJobAction.RETRY)
                                     continue;
                                 // Cancel or close dialog return false
                                 return false;
                                 // Skip continues
                             }
                             break;
-                        } while(true);
+                        } while (true);
                     }
                 }
                 // The entry is a regular file, copy it
-                else  {
+                else {
                     // Create the file's parent directory(s) if it doesn't already exist
                     AbstractFile destParentFile = destFile.getParent();
-                    if(!destParentFile.exists()) {
+                    if (!destParentFile.exists()) {
                         // Use mkdirs() instead of mkdir() to create any parent folder that doesn't exist yet
                         destParentFile.mkdirs();
                     }
@@ -293,27 +297,46 @@ public class UnpackJob extends AbstractCopyJob {
                     // The entry is wrapped in a ProxyFile to override #getInputStream() and delegate it to
                     // ArchiveFile#getEntryInputStream in order to take advantage of the ArchiveEntryIterator, which for
                     // some archive file implementations (such as TAR) can speed things by an order of magnitude.
-                    if(!tryCopyFile(new ProxiedEntryFile(entryFile, entry, archiveFile, iterator), destFile, append, errorDialogTitle))
-                       return false;
+                    if (!tryCopyFile(new ProxiedEntryFile(entryFile, entry, archiveFile, iterator), destFile, append, errorDialogTitle))
+                        return false;
                 }
             }
 
             return true;
-        }
-        catch(IOException e) {
+        } catch (IOException e) {
             showErrorDialog(errorDialogTitle, Translator.get("cannot_read_file", archiveFile.getName()));
-        }
-        finally {
+        } finally {
             // The ArchiveEntryIterator must be closed when finished
-            if(iterator!=null) {
-                try { iterator.close(); }
-                catch(IOException e) {
+            if (iterator != null) {
+                try {
+                    iterator.close();
+                } catch (IOException e) {
                     // Not much we can do about it
                 }
             }
         }
 
         return false;
+    }
+
+    /** This methods checks for a zipSlip attack.
+     * It is inspired by the mitigation shown in https://snyk.io/research/zip-slip-vulnerability.
+     * @param destFile destination file to unpack to.
+     * @param destFolder destionation folder where the file is put.
+     * @return false if file is outside the target unpack fodler, true if everything is fine.
+     **/
+    private boolean checkForZipSlip(AbstractFile destFile, AbstractFile destFolder) {
+
+        String canonicalDestinationDirPath = destFolder.getCanonicalPath();
+        if (!canonicalDestinationDirPath.endsWith(File.separator)) {
+            canonicalDestinationDirPath = canonicalDestinationDirPath + File.separator;
+        }
+        String canonicalDestinationFile = destFile.getCanonicalPath();
+        if (!canonicalDestinationFile.startsWith(canonicalDestinationDirPath)) {
+            showErrorDialog(errorDialogTitle, Translator.get("entry_outside_of_target_dir", destFile.getName()));
+            return false;
+        }
+        return true;
     }
 
     // This job modifies the base destination folder and its subfolders
@@ -333,21 +356,21 @@ public class UnpackJob extends AbstractCopyJob {
 
         // If the destination files are located inside an archive, optimize the archive file
         AbstractArchiveFile archiveFile = baseDestFolder.getParentArchive();
-        if(archiveFile!=null && archiveFile.isArchive() && archiveFile.isWritable())
-            optimizeArchive((AbstractRWArchiveFile)archiveFile);
+        if (archiveFile != null && archiveFile.isArchive() && archiveFile.isWritable())
+            optimizeArchive((AbstractRWArchiveFile) archiveFile);
 
         // Unselect all files in the active table upon successful completion
-        if(selectedEntries!=null) {
+        if (selectedEntries != null) {
             ActionManager.performAction(UnmarkAllAction.Descriptor.ACTION_ID, getMainFrame());
         }
     }
 
     @Override
     public String getStatusString() {
-        if(isCheckingIntegrity())
+        if (isCheckingIntegrity())
             return super.getStatusString();
 
-        if(isOptimizingArchive)
+        if (isOptimizingArchive)
             return Translator.get("optimizing_archive", archiveToOptimize.getName());
 
         return Translator.get("unpack_dialog.unpacking_file", getCurrentFilename());

--- a/mucommander-core/src/main/java/com/mucommander/job/impl/UnpackJob.java
+++ b/mucommander-core/src/main/java/com/mucommander/job/impl/UnpackJob.java
@@ -83,7 +83,7 @@ public class UnpackJob extends AbstractCopyJob {
      * @param destFolder destination folder where the files will be copied
      * @param newName the new filename in the destination folder, if <code>null</code> the original filename will be used
      * @param fileExistsAction default action to be performed when a file already exists in the destination, see {@link com.mucommander.ui.dialog.file.FileCollisionDialog} for allowed values
-     * @param selectedEntries  entries to be unpacked
+     * @param selectedEntries entries to be unpacked
      * @param baseArchiveDepth depth of the folder in which the top entries are located. 0 is the highest depth (archive's root folder)
      */
     public UnpackJob(ProgressDialog progressDialog, MainFrame mainFrame, AbstractArchiveFile archiveFile, int baseArchiveDepth, AbstractFile destFolder, String newName, int fileExistsAction, List<ArchiveEntry> selectedEntries) {
@@ -104,23 +104,24 @@ public class UnpackJob extends AbstractCopyJob {
         super.jobStarted();
 
         // Create the base destination folder if it doesn't exist yet
-        if (!baseDestFolder.exists()) {
+        if(!baseDestFolder.exists()) {
             // Loop for retry
             do {
                 try {
                     baseDestFolder.mkdir();
-                } catch (IOException e) {
+                }
+                catch(IOException e) {
                     // Unable to create folder
                     int ret = showErrorDialog(errorDialogTitle, Translator.get("cannot_create_folder", baseDestFolder.getName()));
                     // Retry loops
-                    if (ret == FileJobAction.RETRY)
+                    if(ret==FileJobAction.RETRY)
                         continue;
                     // Cancel or close dialog interrupts the job
                     interrupt();
                     // Skip continues
                 }
                 break;
-            } while (true);
+            } while(true);
         }
     }
 
@@ -142,14 +143,14 @@ public class UnpackJob extends AbstractCopyJob {
         AbstractFile destFolder = baseDestFolder;
 
         // If the file is a directory, process its children recursively
-        if (file.isDirectory()) {
+        if(file.isDirectory()) {
             do {    // Loop for retries
                 try {
                     // List files inside archive file (can throw an IOException)
                     AbstractFile[] archiveFiles = getCurrentFile().ls();
 
                     // Recurse on zip's contents
-                    for (int j = 0; j < archiveFiles.length && getState() != FileJobState.INTERRUPTED; j++) {
+                    for(int j=0; j<archiveFiles.length && getState() != FileJobState.INTERRUPTED; j++) {
                         // Notify job that we're starting to process this file (needed for recursive calls to processFile)
                         nextFile(archiveFiles[j]);
                         // Recurse
@@ -157,20 +158,21 @@ public class UnpackJob extends AbstractCopyJob {
                     }
                     // Return true when complete
                     return true;
-                } catch (IOException e) {
+                }
+                catch(IOException e) {
                     // File could not be uncompressed properly
                     int ret = showErrorDialog(errorDialogTitle, Translator.get("cannot_read_file", getCurrentFilename()));
                     // Retry loops
-                    if (ret == FileJobAction.RETRY)
+                    if(ret==FileJobAction.RETRY)
                         continue;
                     // cancel, skip or close dialog will simply return false
                     return false;
                 }
-            } while (true);
+            } while(true);
         }
 
         // Abort if the file is neither an archive file nor a directory
-        if (!file.isArchive())
+        if(!file.isArchive())
             return false;
 
         // 'Cast' the file as an archive file
@@ -187,26 +189,28 @@ public class UnpackJob extends AbstractCopyJob {
         // Unpack the archive, copying entries one by one, in the iterator's order
         try {
             iterator = archiveFile.getEntryIterator();
-            while ((entry = iterator.nextEntry()) != null && getState() != FileJobState.INTERRUPTED) {
+            while((entry = iterator.nextEntry())!=null && getState() != FileJobState.INTERRUPTED) {
                 entryPath = entry.getPath();
 
                 boolean processEntry = false;
-                if (selectedEntries == null) {    // Entries are processed
+                if(selectedEntries ==null) {    // Entries are processed
                     processEntry = true;
-                } else {                          // We need to determine if the entry should be processed or not
+                }
+                else {                          // We need to determine if the entry should be processed or not
                     // Process this entry if the selectedEntries set contains this entry, or a parent of this entry
                     int nbSelectedEntries = selectedEntries.size();
-                    for (int i = 0; i < nbSelectedEntries; i++) {
+                    for(int i=0; i<nbSelectedEntries; i++) {
                         ArchiveEntry selectedEntry = selectedEntries.get(i);
                         // Note: paths of directory entries must end with '/', so this compares whether
                         // selectedEntry is a parent of the current entry.
-                        if (selectedEntry.isDirectory()) {
-                            if (entryPath.startsWith(selectedEntry.getPath())) {
+                        if(selectedEntry.isDirectory()) {
+                            if(entryPath.startsWith(selectedEntry.getPath())) {
                                 processEntry = true;
                                 break;
                                 // Note: we can't remove selectedEntryPath from the set, we still need it
                             }
-                        } else if (entryPath.equals(selectedEntry.getPath())) {
+                        }
+                        else if(entryPath.equals(selectedEntry.getPath())) {
                             // If the (regular file) entry is in the set, remove it as we no longer need it (will speed up
                             // subsequent searches)
                             processEntry = true;
@@ -216,7 +220,7 @@ public class UnpackJob extends AbstractCopyJob {
                     }
                 }
 
-                if (!processEntry)
+                if(!processEntry)
                     continue;
 
                 // Resolve the entry file
@@ -226,15 +230,16 @@ public class UnpackJob extends AbstractCopyJob {
                 nextFile(entryFile);
 
                 // Figure out the destination file's path, relatively to the base destination folder
-                relDestPath = baseArchiveDepth == 0
-                        ? entry.getPath()
-                        : PathUtils.removeLeadingFragments(entry.getPath(), "/", baseArchiveDepth);
+                relDestPath = baseArchiveDepth==0
+                        ?entry.getPath()
+                        :PathUtils.removeLeadingFragments(entry.getPath(), "/", baseArchiveDepth);
 
-                if (newName != null)
-                    relDestPath = newName + (PathUtils.getDepth(relDestPath, "/") <= 1 ? "" : "/" + PathUtils.removeLeadingFragments(relDestPath, "/", 1));
+                if(newName!=null)
+                    relDestPath = newName+(PathUtils.getDepth(relDestPath, "/")<=1?"":"/"+PathUtils.removeLeadingFragments(relDestPath, "/", 1));
 
-                if (!"/".equals(destSeparator))
+                if(!"/".equals(destSeparator))
                     relDestPath = relDestPath.replace("/", destSeparator);
+
                 // Create destination AbstractFile instance
                 destFile = destFolder.getChild(relDestPath);
 
@@ -244,7 +249,7 @@ public class UnpackJob extends AbstractCopyJob {
                     return false;
 
                 // Do nothing if the file is a symlink (skip file and return)
-                if (entryFile.isSymlink())
+                if(entryFile.isSymlink())
                     return true;
 
                 // Check if the file does not already exist in the destination
@@ -257,34 +262,36 @@ public class UnpackJob extends AbstractCopyJob {
                 // It is noteworthy that the iterator returns entries in no particular order (consider it random).
                 // For that reason, we cannot assume that the parent directory of an entry will be processed
                 // before the entry itself.
+
                 // If the entry is a directory ...
-                if (entryFile.isDirectory()) {
+                if(entryFile.isDirectory()) {
                     // Create the directory in the destination, if it doesn't already exist
-                    if (!(destFile.exists() && destFile.isDirectory())) {
+                    if(!(destFile.exists() && destFile.isDirectory())) {
                         // Loop for retry
                         do {
                             try {
                                 // Use mkdirs() instead of mkdir() to create any parent folder that doesn't exist yet
                                 destFile.mkdirs();
-                            } catch (IOException e) {
+                            }
+                            catch(IOException e) {
                                 // Unable to create folder
                                 int ret = showErrorDialog(errorDialogTitle, Translator.get("cannot_create_folder", entryFile.getName()));
                                 // Retry loops
-                                if (ret == FileJobAction.RETRY)
+                                if(ret==FileJobAction.RETRY)
                                     continue;
                                 // Cancel or close dialog return false
                                 return false;
                                 // Skip continues
                             }
                             break;
-                        } while (true);
+                        } while(true);
                     }
                 }
                 // The entry is a regular file, copy it
-                else {
+                else  {
                     // Create the file's parent directory(s) if it doesn't already exist
                     AbstractFile destParentFile = destFile.getParent();
-                    if (!destParentFile.exists()) {
+                    if(!destParentFile.exists()) {
                         // Use mkdirs() instead of mkdir() to create any parent folder that doesn't exist yet
                         destParentFile.mkdirs();
                     }
@@ -292,20 +299,21 @@ public class UnpackJob extends AbstractCopyJob {
                     // The entry is wrapped in a ProxyFile to override #getInputStream() and delegate it to
                     // ArchiveFile#getEntryInputStream in order to take advantage of the ArchiveEntryIterator, which for
                     // some archive file implementations (such as TAR) can speed things by an order of magnitude.
-                    if (!tryCopyFile(new ProxiedEntryFile(entryFile, entry, archiveFile, iterator), destFile, append, errorDialogTitle))
-                        return false;
+                    if(!tryCopyFile(new ProxiedEntryFile(entryFile, entry, archiveFile, iterator), destFile, append, errorDialogTitle))
+                       return false;
                 }
             }
 
             return true;
-        } catch (IOException e) {
+        }
+        catch(IOException e) {
             showErrorDialog(errorDialogTitle, Translator.get("cannot_read_file", archiveFile.getName()));
-        } finally {
+        }
+        finally {
             // The ArchiveEntryIterator must be closed when finished
-            if (iterator != null) {
-                try {
-                    iterator.close();
-                } catch (IOException e) {
+            if(iterator!=null) {
+                try { iterator.close(); }
+                catch(IOException e) {
                     // Not much we can do about it
                 }
             }
@@ -351,21 +359,21 @@ public class UnpackJob extends AbstractCopyJob {
 
         // If the destination files are located inside an archive, optimize the archive file
         AbstractArchiveFile archiveFile = baseDestFolder.getParentArchive();
-        if (archiveFile != null && archiveFile.isArchive() && archiveFile.isWritable())
-            optimizeArchive((AbstractRWArchiveFile) archiveFile);
+        if(archiveFile!=null && archiveFile.isArchive() && archiveFile.isWritable())
+            optimizeArchive((AbstractRWArchiveFile)archiveFile);
 
         // Unselect all files in the active table upon successful completion
-        if (selectedEntries != null) {
+        if(selectedEntries!=null) {
             ActionManager.performAction(UnmarkAllAction.Descriptor.ACTION_ID, getMainFrame());
         }
     }
 
     @Override
     public String getStatusString() {
-        if (isCheckingIntegrity())
+        if(isCheckingIntegrity())
             return super.getStatusString();
 
-        if (isOptimizingArchive)
+        if(isOptimizingArchive)
             return Translator.get("optimizing_archive", archiveToOptimize.getName());
 
         return Translator.get("unpack_dialog.unpacking_file", getCurrentFilename());

--- a/mucommander-translator/src/main/resources/dictionary.properties
+++ b/mucommander-translator/src/main/resources/dictionary.properties
@@ -782,3 +782,4 @@ delete.delete_link_only = Delete link
 delete.delete_linked_folder = Delete folder
 Unpack.label = Unpack files
 Pack.label = Pack files
+entry_outside_of_target_dir=Entry is outside of the target dir: {0}


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://huntr.dev/bounties/1-other-mucommander

### ⚙️ Description *

There is a general implementation in muCommander for unpacking archives. That already does some checks, wether the file is a symlink etc. To that checks a check for zipSlip, inspired by the blueprint fix in https://snyk.io/research/zip-slip-vulnerability has been added.

### 💻 Technical Description *

The blueprint check in https://snyk.io/research/zip-slip-vulnerability has been adopted to work in muCommanders unpack job.
The check determines the canonical path of the destination folder and the canonical path of the target file to be unpacked.
It then checks wether the target file is in the destination folder.  

### 🐛 Proof of Concept (PoC) *

Take the zip file in the issue and unpack in using mucommander. It will create a file "good.txt" in the chosen destination folder and a file evil.txt in /tmp.

### 🔥 Proof of Fix (PoF) *

Take the zip file in the issue and unpack in using mucommander. It will create a file "good.txt" in the chosen destination folder and raise an error "Entry is outside of the target dir: evil.txt". It will not create the file /tmp/evil.txt while unpacking.

### 👍 User Acceptance Testing (UAT)

See PoF
